### PR TITLE
[add] ShareGPT4V-7B and ShareGPT4V-13B

### DIFF
--- a/t2i_metrics/models/vqascore_models/llava/model/multimodal_encoder/builder.py
+++ b/t2i_metrics/models/vqascore_models/llava/model/multimodal_encoder/builder.py
@@ -5,7 +5,7 @@ from .clip_encoder import CLIPVisionTower
 def build_vision_tower(vision_tower_cfg, **kwargs):
     vision_tower = getattr(vision_tower_cfg, 'mm_vision_tower', getattr(vision_tower_cfg, 'vision_tower', None))
     is_absolute_path_exists = os.path.exists(vision_tower)
-    if is_absolute_path_exists or vision_tower.startswith("openai") or vision_tower.startswith("laion"):
+    if is_absolute_path_exists or vision_tower.startswith("openai") or vision_tower.startswith("laion") or vision_tower.startswith("Lin-Chen"):
         return CLIPVisionTower(vision_tower, args=vision_tower_cfg, **kwargs)
 
     raise ValueError(f'Unknown vision tower: {vision_tower}')

--- a/t2i_metrics/models/vqascore_models/llava_model.py
+++ b/t2i_metrics/models/vqascore_models/llava_model.py
@@ -80,6 +80,27 @@ LLAVA_MODELS = {
             'image_aspect_ratio': 'square',
         },
     },
+    # The following models are built on top of LLaVA-1.5 and integrate well with LLaVA-1.5 codebase
+    'ShareGPT4V-7B': {
+        'tokenizer' : {
+            'path': 'Lin-Chen/ShareGPT4V-7B',
+        },
+        'model': {
+            'path': 'Lin-Chen/ShareGPT4V-7B',
+            'conversation': 'chat',
+            'image_aspect_ratio': 'pad',
+        },
+    },
+    'ShareGPT4V-13B': {
+        'tokenizer' : {
+            'path': 'Lin-Chen/ShareGPT4V-13B',
+        },
+        'model': {
+            'path': 'Lin-Chen/ShareGPT4V-13B',
+            'conversation': 'chat',
+            'image_aspect_ratio': 'pad',
+        },
+    },
 }
 
 

--- a/t2i_metrics/models/vqascore_models/llava_model.py
+++ b/t2i_metrics/models/vqascore_models/llava_model.py
@@ -81,7 +81,7 @@ LLAVA_MODELS = {
         },
     },
     # The following models are built on top of LLaVA-1.5 and integrate well with LLaVA-1.5 codebase
-    'ShareGPT4V-7B': {
+    'sharegpt4v-7b': {
         'tokenizer' : {
             'path': 'Lin-Chen/ShareGPT4V-7B',
         },
@@ -91,7 +91,7 @@ LLAVA_MODELS = {
             'image_aspect_ratio': 'pad',
         },
     },
-    'ShareGPT4V-13B': {
+    'sharegpt4v-13b': {
         'tokenizer' : {
             'path': 'Lin-Chen/ShareGPT4V-13B',
         },


### PR DESCRIPTION
I am adding the support for ShareGPT4V-7B and ShareGPT4V-13B. They perform comparatively with LLaVA-1.5 and they integrate well with LLaVA-1.5 codebase.

Paper: https://arxiv.org/abs/2311.12793
Code: https://github.com/InternLM/InternLM-XComposer/tree/main/projects/ShareGPT4V
Page: https://sharegpt4v.github.io/